### PR TITLE
Clean up docs and git hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Every modality, one search. Local first.**
 
-![RecallForge — Your Files → One Search](docs/hero-banner.png)
+![RecallForge — Your Files → One Search](https://raw.githubusercontent.com/brianmeyer/recallforge/master/docs/hero-banner.png)
 
 Standard RAG only works on text. Drop a PDF with charts, a photo of a whiteboard, a video recording, or a transcript-backed audio note — and your AI agent goes blind. RecallForge gives agents **eyes and ears over your local filesystem**. Text, images, documents, video, and audio transcripts all live in one unified search space, and nothing ever leaves your machine.
 
@@ -293,7 +293,7 @@ pytest tests/ -m live -v       # Integration tests (requires models)
 
 CI in `.github/workflows/ci.yml` runs the test matrix, builds distributions, runs `twine check`, smoke-tests wheel installation, and smoke-tests the HTTP server extra from the built wheel. Tagged pushes matching `v*` trigger `.github/workflows/publish.yml`, which publishes to PyPI with trusted publishing.
 
-Before tagging a release, run the repo test suite plus the install/CLI UAT scripts, and if you are on a capable host, run the live integration slice and expanded benchmark. The full checklist lives in [docs/RELEASE.md](docs/RELEASE.md).
+Before tagging a release, run the repo test suite plus the install/CLI UAT scripts, and if you are on a capable host, run the live integration slice and expanded benchmark. The full checklist lives in [docs/RELEASE.md](docs/RELEASE.md), and routine branch/worktree cleanup lives in [docs/GIT_HYGIENE.md](docs/GIT_HYGIENE.md).
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for full development guidelines.
 

--- a/docs/GIT_HYGIENE.md
+++ b/docs/GIT_HYGIENE.md
@@ -1,0 +1,59 @@
+# RecallForge Git Hygiene
+
+Use this checklist after releases, merged PRs, and long agent sessions.
+
+## Current Repository Policy
+
+- Default branch: `master`
+- Release tags: `vX.Y.Z`
+- Agent branches: `codex/<short-description>`
+- GitHub merged-head branch cleanup: enabled
+
+GitHub automatically deletes PR head branches after merge. Local cleanup is still useful because remote-tracking refs, generated build artifacts, and extra worktrees can hang around on a developer machine.
+
+## Routine Cleanup
+
+Check repository state:
+
+```bash
+git status --short --branch
+git fetch --prune
+git branch --all --verbose --no-abbrev
+git worktree list --porcelain
+gh pr list --repo brianmeyer/recallforge --state open --limit 20
+gh run list --repo brianmeyer/recallforge --limit 10
+```
+
+Remove local merged branches after confirming they are no longer needed:
+
+```bash
+git switch master
+git pull --ff-only recallforge master
+git branch --merged master
+git branch -d codex/<merged-branch>
+```
+
+Remove ignored local build/test artifacts:
+
+```bash
+rm -rf build dist src/recallforge.egg-info .pytest_cache
+```
+
+Do not remove unmerged branches, alternate worktrees, or user-created files unless they are clearly part of the cleanup task.
+
+## Release Cleanup
+
+After a release tag is pushed:
+
+```bash
+gh run list --repo brianmeyer/recallforge --workflow publish.yml --limit 5
+python -m pip index versions recallforge
+python -m pip install "recallforge==X.Y.Z"
+```
+
+Then verify:
+
+- `master` is clean and current with `recallforge/master`
+- the release tag points at the intended merge commit
+- no release PRs are left open
+- PyPI shows the new version as latest

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -109,10 +109,16 @@ When you omit `--output`, the benchmark now keeps profile-specific filenames for
 
 ```bash
 git tag vX.Y.Z
-git push origin vX.Y.Z
+git push recallforge vX.Y.Z
 ```
 
-3. Watch the `Publish to PyPI` workflow complete successfully.
+If your checkout uses a conventional `origin` remote instead of `recallforge`, push the tag to `origin`.
+
+3. Watch the `Publish to PyPI` workflow complete successfully:
+
+```bash
+gh run list --repo brianmeyer/recallforge --workflow publish.yml --limit 5
+```
 
 ## 5. Post-release smoke check
 
@@ -125,3 +131,7 @@ recallforge serve --http --mode embed --host 127.0.0.1 --port 7433
 ```
 
 Then hit `http://127.0.0.1:7433/health` and confirm the process reports healthy model state.
+
+## 6. Git cleanup
+
+After the release PR is merged and the tag is published, follow the routine in [`docs/GIT_HYGIENE.md`](GIT_HYGIENE.md) to prune remote-tracking refs, remove local merged branches, and clear generated build artifacts.


### PR DESCRIPTION
## Summary

- make the README hero image render outside GitHub, including PyPI long descriptions, by using the raw GitHub asset URL
- add `docs/GIT_HYGIENE.md` with the repeatable branch/worktree/artifact cleanup routine
- tighten release docs around this repo's `recallforge` remote, publish workflow watching, and post-release git cleanup
- enable GitHub's `delete_branch_on_merge` repository setting so merged PR head branches are cleaned up automatically

## Validation

- `git diff --check`
- `python -m build`
- `twine check dist/*`
- local Markdown link check for README, RELEASE, and GIT_HYGIENE

## Linear

No existing open Linear ticket maps directly to docs/git hygiene after REC-180 shipped, so this is a small setup cleanup before starting the next backlog ticket.