### PR TITLE
Release RecallForge 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RecallForge will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.1] — 2026-05-17
+
+RecallForge 0.3.1 is the final project closeout release for the Memory MCP launch push. It publishes the post-0.3.0 Linear work that landed after the original 0.3.0 tag.
+
 - Added staged background reindex promotion so document, video, audio, and conversation replacements stay hidden until their parent/child memory batches are complete.
 - Added index-version-aware query caching for repeated text/media embeddings and generated expansion branches.
 - Added MCP progress notifications for long-running search, ingest, batch, memory write, and FTS rebuild tool calls when clients provide a progress token.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "recallforge"
-version = "0.3.0"
+version = "0.3.1"
 description = "Local multimodal memory for AI agents — cross-modal vision-language search"
 authors = [{name = "Brian Meyer", email = "brian@recallforge.dev"}]
 readme = "README.md"

--- a/src/recallforge/__init__.py
+++ b/src/recallforge/__init__.py
@@ -24,7 +24,7 @@ import os
 import warnings
 from typing import Optional, Tuple
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 
 def _has_torch() -> bool:

--- a/tests/test_cross_modal_benchmark_defs.py
+++ b/tests/test_cross_modal_benchmark_defs.py
@@ -7,6 +7,8 @@ import sys
 import unittest
 from pathlib import Path
 
+from recallforge import __version__
+
 
 def _load_cross_modal_ablation():
     repo_root = Path(__file__).resolve().parent.parent
@@ -298,7 +300,7 @@ class TestCrossModalBenchmarkDefinitions(unittest.TestCase):
             error="Interrupted by user",
         )
 
-        self.assertEqual(payload["version"], "0.3.0")
+        self.assertEqual(payload["version"], __version__)
         self.assertEqual(payload["configuration"]["expansion_profile"], "caption_only")
         self.assertEqual(payload["configuration"]["smoke_profile"], "safe")
         self.assertEqual(payload["configuration"]["rss_limit_mb"], 4096)


### PR DESCRIPTION
## Summary
- Bump RecallForge package/runtime version to 0.3.1
- Move the final post-0.3.0 Linear closeout work into a 0.3.1 changelog section
- Make the benchmark payload version assertion follow `recallforge.__version__`

## Why
PyPI already has immutable `0.3.0` published from tag `v0.3.0`; current `master` contains additional merged Linear work. This release publishes the actual finished closeout tree.

## Validation
- `python3 -m compileall -q src tests`
- `python3 -m pytest -q` (563 passed, 18 skipped, 18 subtests passed)
- `bash tests/uat/test_mcp_server.sh` (PASS 63 / FAIL 0)
- `.venv/bin/python -m pip wheel . -w /tmp/recallforge-wheel-031`
- `PYTHONPATH=/tmp/recallforge-twine .venv/bin/python -m twine check /tmp/recallforge-wheel-031/recallforge-0.3.1-py3-none-any.whl`
- `python3 -m recallforge.cli --version` -> `RecallForge 0.3.1`
